### PR TITLE
Upgrades underscore version. Fixes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "backbone": "~1.3.3",
-    "underscore": "~1.8.3"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "babel-core": "6.25.0",
@@ -78,6 +78,6 @@
     "sinon": "1.17.6",
     "sinon-chai": "2.8.0",
     "uglify-js": "^3.0.27",
-    "underscore": "1.8 - 1.8.3"
+    "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
### Proposed changes
 - Upgrades the underscore version to a caret version 1.8.3
 
Tests run successfully. I haven't updated yarn.lock since I don't use yarn.

Link to the issue:
#1 