### PR TITLE
Upgrades backbone version. Fixes #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "backbone.marionette": "^4.0.0, 4.0.0-beta.1"
   },
   "peerDependencies": {
-    "backbone": "~1.3.3",
+    "backbone": "^1.3.3",
     "underscore": "~1.8.3"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "babel-eslint": "7.0.0",
     "babel-preset-es2015": "6.24.1",
     "babel-register": "6.24.1",
-    "backbone": "1.2.1 - 1.3.x",
+    "backbone": "^1.3.3",
     "chai": "3.5.0",
     "chai-jq": "0.0.9",
     "eslint": "3.7.1",


### PR DESCRIPTION
### Proposed changes
 - Upgrades the backbone dependency to a caret version, allowing to update to backbone 1.4

Tests are running successfully. I didn't update yarn.lock as I'm not using yarn.
 
Link to the issue:
#4 